### PR TITLE
Fixing global drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Work in progress. Check [TODO](#TODO) list below.
 - [gnuplot](https://command-not-found.com/gnuplot) for visualization
 - [xz](https://command-not-found.com/xz) for trajectory compression
 - [ffmpeg](https://command-not-found.com/ffmpeg) for movie generation
+- [jq](https://command-not-found.com/jq), [curl](https://command-not-found.com/curl) and [sponge](https://command-not-found.com/sponge) for quotes
 
 # Build
 - Install, if non-existent, the above [dependencies](#dependencies) first
@@ -101,6 +102,9 @@ ccd -p '<parameterA>=<valueA>' -p '<parameterB>=<valueB>' show_params
 - Retrieve the run results later, as necessary, by providing the corresponding metadata file to `ccd retrieve`.
 
 - Backup the archive (`${HOME}/.ccd`) from time to time, copying the new files only.
+
+### Quotes
+To turn off the GROMACS-like quotes at the end of each command, set the `CCD_NO_QUOTES` enviroment variable. Do so if you mostly use `ccd` when offline.
 
 # Note
 If met with segmentation faults or stack-smashing error, make the stack size unlimited in the Bash session with `ulimit -s unlimited; export OMP_STACKSIZE=500m`.

--- a/scripts/ccd_exit.sh
+++ b/scripts/ccd_exit.sh
@@ -4,3 +4,6 @@
 
 # Remove the hidden parameter file actually used by the sim engine
 rm -f .params.in
+
+# Show quote
+ccd_quote

--- a/scripts/ccd_quote
+++ b/scripts/ccd_quote
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Brief: Quotes manager. Downloads random quotes, caches them and displays.
+# Quotes courtesy: https://zenquotes.io/
+
+[[ -z "${CCD_NO_QUOTES}" ]] || exit
+
+set -o pipefail
+
+export CCD_HOME="${HOME}"/.ccd
+mkdir -p "${CCD_HOME}"
+export quotes_cache="${CCD_HOME}/quotes"
+
+show_quote(){
+  # Shows one quote from the cache and removes it from the cache 
+  [[ -s "${quotes_cache}" ]] || return 1
+  echo -en "\nCCD Reminds You:  "
+  head -n1 "${quotes_cache}"
+  tail -n+2 "${quotes_cache}" | sponge "${quotes_cache}"
+} 1>&2 2>/dev/null
+
+cache_quotes(){
+  # Downloads and caches a bunch of quotes
+  timeout 3 curl -Lsf -o- https://zenquotes.io/api/quotes | jq -r '.[] | "\"" + .q + "\"" + "(" + .a + ")"' || \
+  echo '"I am out of quotes. Connect me to the internet so that I can topup."(poor CCD)'
+} >> "${quotes_cache}" 2>/dev/null
+
+show_quote || (cache_quotes && show_quote)

--- a/src/ccd_init.f90
+++ b/src/ccd_init.f90
@@ -1,8 +1,13 @@
+!Brief: Initializes state. Positions are initialized randomly. Motility vectors initialized isotropically by default.
+!Usage: ccd_init [-r | --random]
+! -r | --random : Initialize motility unit vectors randomly. Vicsek order parameter may not be zero.
+
 program ccd_init
     use parameters
     use state_vars
     use init
     use files
+    use utilities, only: cmd_line_flag
     implicit none
     
     integer :: clock_tick
@@ -20,7 +25,9 @@ program ccd_init
     call random_seed(put = prng_seeds)
 
     call initial()
-    call initial_angle()
+    if (cmd_line_flag('-r') .or. cmd_line_flag('--random')) call initial_angle()
     
     call cpt_write(timepoint, recnum, 0, 1)
+    
+    write(*,'(a,1x,"(",es23.16,",",es23.16,")")') 'Average motility vector:', sum(mx)/(m*n), sum(my)/(m*n)
 end program ccd_init

--- a/src/ccd_run.f90
+++ b/src/ccd_run.f90
@@ -1,9 +1,10 @@
 ! Brief: The main run engine. Produces trajectory starting from an initial state provided by a checkpoint.
 ! Prerequisites: checkpoint, parameter file, trajectory to append to if --append flag is on.
-! Synopsis: ccd_run [--append | -a] [--force | -f] [-n | --no-status-dump]
+! Synopsis: ccd_run [--append | -a] [--force | -f] [-n | --no-status-dump] [--no-evolve-motility]
 ! --append : append to an existing trajectory thus extending a previous run
 ! --force : ignore lockfile left behind by a previous incomplete run
-! --no-status-dump : Doesn't show live progess. This makes the run faster. 
+! --no-status-dump : Doesn't show live progess. This makes the run faster.
+! --no-evolve-motility : Doesn't evolve the motility (unit) vectors with time
 
 program ccd_run
 	use shared

--- a/src/mod_forces.f90
+++ b/src/mod_forces.f90
@@ -12,14 +12,14 @@ contains
 	integer:: i,l
         double precision::l1,l2,dx1,dx2,dy1,dy2
         integer :: i_minus_1, i_plus_1
-   
+        double precision, dimension(size(x,dim=1)):: f_bead_x, f_bead_y
+        double precision :: f_bead_x_avg, f_bead_y_avg
           
 
          
      
-    !$omp do private(i,l, l1,l2,dx1,dx2,dy1,dy2, i_minus_1,i_plus_1)
+    !$omp do private(i,l, l1,l2,dx1,dx2,dy1,dy2, i_minus_1,i_plus_1, f_bead_x,f_bead_y,f_bead_x_avg,f_bead_y_avg)
   	do l=1,m
-
         do i=1,n
 
                    i_minus_1 = modulo(i-2,n) + 1
@@ -39,14 +39,21 @@ contains
 
                    l2 = dsqrt(dx2*dx2 + dy2*dy2)
 
-                   fx(i,l)=k*((l1-l0)*dx1/l1 - (l2-l0)*dx2/l2) &
+                   f_bead_x(i)=k*((l1-l0)*dx1/l1 - (l2-l0)*dx2/l2) &
                                 - 0.5d0*p*l0*(dy1/l1 + dy2/l2) 
                      
 
-                   fy(i,l)=k*((l1-l0)*dy1/l1 - (l2-l0)*dy2/l2) &
+                   f_bead_y(i)=k*((l1-l0)*dy1/l1 - (l2-l0)*dy2/l2) &
                                 + 0.5d0*p*l0*(dx1/l1 + dx2/l2)
 
 	  end do
+    
+      f_bead_x_avg = sum(f_bead_x)/n
+      f_bead_y_avg = sum(f_bead_y)/n
+      
+      fx(:,l) = f_bead_x(:) - f_bead_x_avg ! Because total intra force for any cell/ring must be zero
+      fy(:,l) = f_bead_y(:) - f_bead_y_avg ! e.g. a live amoeba in vacuum can have no net movement
+    
     end do
     !$omp end do nowait
 		 

--- a/src/mod_forces.f90
+++ b/src/mod_forces.f90
@@ -20,6 +20,9 @@ contains
      
     !$omp do private(i,l, l1,l2,dx1,dx2,dy1,dy2, i_minus_1,i_plus_1, f_bead_x,f_bead_y,f_bead_x_avg,f_bead_y_avg)
   	do l=1,m
+        f_bead_x_avg = 0.d0
+        f_bead_y_avg = 0.d0
+        
         do i=1,n
 
                    i_minus_1 = modulo(i-2,n) + 1
@@ -43,13 +46,16 @@ contains
                                 - 0.5d0*p*l0*(dy1/l1 + dy2/l2) 
                      
 
+                   f_bead_x_avg = f_bead_x_avg + f_bead_x(i)
+
                    f_bead_y(i)=k*((l1-l0)*dy1/l1 - (l2-l0)*dy2/l2) &
                                 + 0.5d0*p*l0*(dx1/l1 + dx2/l2)
 
+                   f_bead_y_avg = f_bead_y_avg + f_bead_y(i)
 	  end do
     
-      f_bead_x_avg = sum(f_bead_x)/n
-      f_bead_y_avg = sum(f_bead_y)/n
+      f_bead_x_avg = f_bead_x_avg/n
+      f_bead_y_avg = f_bead_y_avg/n
       
       fx(:,l) = f_bead_x(:) - f_bead_x_avg ! Because total intra force for any cell/ring must be zero
       fy(:,l) = f_bead_y(:) - f_bead_y_avg ! e.g. a live amoeba in vacuum can have no net movement

--- a/src/mod_init.f90
+++ b/src/mod_init.f90
@@ -55,18 +55,21 @@ seed_cell_centres: do l=2,m
 end do seed_cell_centres
 
 ! Construct circular cells from the seeded centres
+! Also initialize the motility unit vectors symmetrically (radially outward) such that the total for each cell is null
 do l=1,m
     do i=1,n        
         theta1 = (i-1)*2.0d0*pi/n
         x(i,l) = radius*dcos(theta1) + xcell(l)
         y(i,l) = radius*dsin(theta1) + ycell(l)
+        mx(i,l)= dcos(theta1)
+        my(i,l)= dsin(theta1)
      end do
 end do
 
 	return
 	end subroutine initial
 
-!! Subroutine for initializaion of noise-angle
+!! Subroutine for random initializaion of motility unit vectors
        subroutine initial_angle()
         double precision :: m_tmp,mx_tmp,my_tmp
         integer :: i,l

--- a/src/mod_integrator.f90
+++ b/src/mod_integrator.f90
@@ -1,6 +1,7 @@
 module integrator
 
 implicit none
+double precision :: evolve_motility_bool=1.0d0
 
 contains
 
@@ -24,7 +25,7 @@ contains
            y(i,l) = y(i,l) + vy
             
       
-            wz = (mx(i,l)*vy - my(i,l)*vx)/(tau_align*dt) + noise(tmp+i)
+            wz = ((mx(i,l)*vy - my(i,l)*vx)/(tau_align*dt) + noise(tmp+i))*evolve_motility_bool
             theta_x = -my(i,l)*wz*dt
             theta_y = mx(i,l)*wz*dt
             theta_sq_by_4 = (theta_x*theta_x + theta_y*theta_y)/4.0d0

--- a/src/mod_parameters.f90
+++ b/src/mod_parameters.f90
@@ -1,24 +1,24 @@
 module parameters
     implicit none
     public
-    double precision, protected:: k=120.0d0      !  Single cell spring constant
-    double precision, protected:: p=25.0d0       !  Single cell internal hydrostatic pressure coefficient
+    double precision, protected:: k=240.0d0      !  Single cell spring constant
+    double precision, protected:: p=50.0d0       !  Single cell internal hydrostatic pressure coefficient
     double precision, protected:: l0=0.1d0       !  Single cell natural spring-length
     double precision, protected:: rc_adh=0.28d0  ! Adhesion interaction cut-off
     double precision, protected:: rc_rep=0.18d0  ! Repulsion interaction cut-off
-    double precision, protected:: k_adh=0.001d0   !  Adhesion interaction strength
-    double precision, protected:: k_rep=1000.0d0 !  Adhesion interaction strength
+    double precision, protected:: k_adh=0.002d0   !  Adhesion interaction strength
+    double precision, protected:: k_rep=2000.0d0 !  Adhesion interaction strength
     double precision, parameter:: mean=0.0d0     !  Mean of the gaussian white noise
     double precision, protected:: var=0.05d0      !  Variance of the gaussian white noise
     double precision, protected:: Vo=0.05d0       !  Self propulsion of the beads
-    double precision, protected:: c = 0.5d0         ! c is coeff. of viscous damping      
+    double precision, parameter:: c = 1.0d0         ! c is coeff. of viscous damping      
     double precision, protected:: dt=0.001d0   ! Integration timestep
     integer, protected:: tau_align=10 ! Tau for Vicsek alignment in multiples of dt
     integer, protected:: nsamples=2  !! No. of Iterations in terms of traj_dump_int
     integer,protected:: n = 50    ! No. of beads
     integer,protected:: m = 256   ! No. of cell
 
-    namelist /params/ k, p, l0, rc_adh, rc_rep, k_adh, k_rep, var, Vo, c, dt, tau_align, nsamples, n, m
+    namelist /params/ k, p, l0, rc_adh, rc_rep, k_adh, k_rep, var, Vo, dt, tau_align, nsamples, n, m
 
     contains
     

--- a/src/mod_prerun.f90
+++ b/src/mod_prerun.f90
@@ -7,6 +7,7 @@ module prerun
         use state_vars
         use parameters
         use files
+        use integrator, only: evolve_motility_bool
         !$ use omp_lib, only: omp_get_max_threads
         
         integer, intent(out) :: ji,jf
@@ -75,5 +76,10 @@ module prerun
         !$ call log_this('Using '//int_to_char(int(omp_get_max_threads(), kind=kind(jf)))//' OpenMP threads')
         
         do_status_dump = .not. (cmd_line_flag('-n') .or. cmd_line_flag('--no-status-dump'))
+        
+        if(cmd_line_flag('--no-evolve-motility')) then
+            evolve_motility_bool=0.0d0
+            call log_this('Motility unit vectors are not being evolved')
+        endif
     end subroutine prerun_setup
 end module prerun

--- a/tests/crash_recovery_check
+++ b/tests/crash_recovery_check
@@ -8,20 +8,20 @@ make FC=ifort rebuild
 # Initialization & hardlinking state.cpt to init.cpt
 ccd init; ln -f state.cpt init.cpt 
 
-# Run nsamples=200 from init.cpt (so that we get 4 checkpoints at 5000 steps interval)
-ccd -p 'nsamples=200' run -n
+# Run nsamples=100 from init.cpt (so that we get 2 checkpoints at 5000 steps interval)
+ccd -p 'nsamples=100' run -n
 ccd cpt_to_xy
 mv -f config.xy config.xy.unfragmented ; mv -f traj.bin traj.bin.unfragmented
 echo 'Finished control run uninterrupted'
 
-# Run nsamples=200 from init.cpt & crash it 
+# Run nsamples=100 from init.cpt & crash it 
 ln -f init.cpt state.cpt
-ccd -p 'nsamples=200' run -n 2> >(tee /dev/stderr | grep -m1 -i 'checkpoint') || echo 'Crashed the test run'
-# stderr/log is piped to grep. When grep sees 1st checkpoint in log, it exists. ccd run gets SIGPIPE and crashes.
+ccd -p 'nsamples=100' run -n 2> >(tee /dev/stderr | (grep -m1 -i 'checkpoint'; killall -r -w -KILL ccd_.*)) || echo 'Crashed the test run'
+# stderr/log is piped to grep. When grep sees 1st checkpoint in log, it exists, triggering a crash using killall or pkill.
 
 
 # Run again, with nothing (parameter-wise) changed except an extra '-f' option, to finish the incomplete part
-ccd -p 'nsamples=200' run -n -f
+ccd -p 'nsamples=100' run -n -f
 ccd cpt_to_xy
 mv -f config.xy config.xy.fragmented ; mv -f traj.bin traj.bin.fragmented
 echo 'Finished the crashed test run'


### PR DESCRIPTION
Total intra force for each cell/ring must be zero. Why? Consider the following:

- intra force depends only on the instantaneous configuration of the corresponding cell and not its neighbors. So, while considering intra force we can think of a single cell only.
-  A single cell, isolated, cannot have any net momentum/movement in absence of external forces. Sum of intra force must be null.

Also, the initial distribution of motility vectors must be completely isotropic to eliminate any possible bias / non-zero Initial Vicsek order parameter.